### PR TITLE
feat: Add manual CSV data upload functionality

### DIFF
--- a/app.py
+++ b/app.py
@@ -68,6 +68,14 @@ if st.sidebar.button("🔓 Sair"):
     st.session_state.clear()  # Reseta a sessão para deslogar
     st.rerun()
 
+# Adiciona o seletor de arquivo na barra lateral
+st.sidebar.header("Carregar Novo Arquivo")
+uploaded_file = st.sidebar.file_uploader(
+    "Escolha um arquivo CSV", type=["csv"]
+)
+if uploaded_file:
+    st.session_state["uploaded_file"] = uploaded_file
+
 # Caminho para armazenar os destinatários dos alertas
 EMAILS_JSON = "emails_destinatarios.json"
 
@@ -259,9 +267,11 @@ if st.session_state.get("tipo") == "admin":
 # VERIFICAÇÃO DE OCORRÊNCIAS E ENVIO DO DASHBOARD POR E-MAIL COM OS DADOS DA DATA MAIS RECENTE
 # =============================================================================
 try:
-    df_pisos = carregar_dados()
+    # Carrega os dados (do arquivo carregado ou do padrão)
+    df_pisos = carregar_dados(st.session_state.get("uploaded_file"))
+
     # Se existir a coluna "Data", filtra os dados pela data mais recente
-    if "Data" in df_pisos.columns:
+    if "Data" in df_pisos.columns and not df_pisos.empty:
         recent_date = df_pisos["Data"].max()
         df_recent = df_pisos[df_pisos["Data"] == recent_date]
     else:

--- a/pages/1_Tabela_Completa.py
+++ b/pages/1_Tabela_Completa.py
@@ -109,7 +109,7 @@ st.title("Tabela Completa")
 st.markdown("<div class='linha'></div>", unsafe_allow_html=True)
 
 # Carregar os Dados
-df = carregar_dados()
+df = carregar_dados(st.session_state.get("uploaded_file"))
 if df.empty:
     st.warning("⚠️ Nenhum dado disponível. Verifique o arquivo CSV.")
     st.stop()

--- a/pages/2_Analise_por_Observacao.py
+++ b/pages/2_Analise_por_Observacao.py
@@ -100,7 +100,7 @@ def display_kpi(label, value, icon):
 st.title("📊 Comparação de Observações por Data")
 
 # 📊 Carregar os dados
-df = carregar_dados()
+df = carregar_dados(st.session_state.get("uploaded_file"))
 
 # 📌 Verificar se os dados foram carregados corretamente
 if df.empty:

--- a/pages/3_Analise_por_Posicao.py
+++ b/pages/3_Analise_por_Posicao.py
@@ -78,7 +78,7 @@ def display_styled_table(df):
     st.markdown(html, unsafe_allow_html=True)
 
 # 📊 Carregar os dados
-df = carregar_dados()
+df = carregar_dados(st.session_state.get("uploaded_file"))
 
 # 📌 Verificar se os dados foram carregados corretamente
 if df.empty:

--- a/pages/4_Analise_por_Piso.py
+++ b/pages/4_Analise_por_Piso.py
@@ -85,7 +85,7 @@ st.markdown(custom_css, unsafe_allow_html=True)
 # Carrega os dados com feedback visual e tratamento de exceção
 with st.spinner("Carregando dados..."):
     try:
-        df = carregar_dados()
+        df = carregar_dados(st.session_state.get("uploaded_file"))
     except Exception as e:
         st.error(f"Erro ao carregar dados: {e}")
         st.stop()

--- a/pages/5_Analise_Total.py
+++ b/pages/5_Analise_Total.py
@@ -95,7 +95,7 @@ def aplicar_estilo():
 aplicar_estilo()
 
 # Carregar os Dados
-df = carregar_dados()
+df = carregar_dados(st.session_state.get("uploaded_file"))
 
 # Filtros de Comparação no Sidebar
 with st.sidebar:

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -2,27 +2,44 @@ import os
 import pandas as pd
 import streamlit as st
 
-CAMINHO_ARQUIVO = "datasets/dados_checklist.csv"
+CAMINHO_ARQUIVO_PADRAO = "datasets/dados_checklist.csv"
 
 @st.cache_data
-def carregar_dados():
-    df = pd.read_csv(CAMINHO_ARQUIVO, sep=";", encoding="latin1")
-    
-    # 🔍 Remover espaços e caracteres estranhos dos nomes das colunas
-    df.columns = df.columns.str.strip().str.replace("�", "ç", regex=False)
+def carregar_dados(uploaded_file=None):
+    """
+    Carrega os dados de um arquivo CSV, seja um arquivo carregado pelo usuário
+    ou o arquivo padrão.
+    """
+    try:
+        if uploaded_file:
+            # Se um arquivo foi carregado, usa-o
+            df = pd.read_csv(uploaded_file, sep=";", encoding="latin1")
+        else:
+            # Caso contrário, usa o caminho padrão
+            if not os.path.exists(CAMINHO_ARQUIVO_PADRAO):
+                st.error(f"Arquivo padrão não encontrado: {CAMINHO_ARQUIVO_PADRAO}")
+                return pd.DataFrame()
+            df = pd.read_csv(CAMINHO_ARQUIVO_PADRAO, sep=";", encoding="latin1")
 
-    # 🔄 Renomear colunas corretamente (caso necessário)
-    colunas_corrigidas = {
-        "Posi��o": "Posição",
-        "PosiÇão": "Posição",
-        "Posição ": "Posição",
-        "Observa��o": "Observação",
-        "ObservaÇão": "Observação",
-        "Observação ": "Observação"
-    }
-    df.rename(columns=colunas_corrigidas, inplace=True)
+        # Limpeza e processamento dos dados
+        df.columns = df.columns.str.strip().str.replace("�", "ç", regex=False)
+        colunas_corrigidas = {
+            "Posi��o": "Posição",
+            "PosiÇão": "Posição",
+            "Posição ": "Posição",
+            "Observa��o": "Observação",
+            "ObservaÇão": "Observação",
+            "Observação ": "Observação",
+        }
+        df.rename(columns=colunas_corrigidas, inplace=True)
 
-    # 📅 Converter coluna "Data" para formato datetime
-    df["Data"] = pd.to_datetime(df["Data"], dayfirst=True, errors="coerce")
+        if "Data" in df.columns:
+            df["Data"] = pd.to_datetime(df["Data"], dayfirst=True, errors="coerce")
+        else:
+            st.warning("A coluna 'Data' não foi encontrada no arquivo.")
 
-    return df
+        return df
+
+    except Exception as e:
+        st.error(f"Ocorreu um erro ao carregar ou processar o arquivo: {e}")
+        return pd.DataFrame()


### PR DESCRIPTION
This commit introduces a new feature that allows users to manually upload their own checklist data as a CSV file.

Key changes include:
- Refactored the `carregar_dados` function to accept a file-like object, with a fallback to the default local CSV file.
- Added a `st.file_uploader` widget to the sidebar in `app.py` to handle file selection.
- Utilized `st.session_state` to ensure the uploaded data persists across all pages of the Streamlit application.
- Updated all pages to use the new data loading mechanism, making the application more robust and flexible.